### PR TITLE
Legger til endepunkt som fjerner hold på persistert dokument

### DIFF
--- a/src/main/kotlin/no/nav/helse/dokument/DokumentService.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/DokumentService.kt
@@ -160,8 +160,8 @@ data class DokumentService(
     fun fjerneHoldPåPersistertDokument(
         dokumentId: DokumentId,
         eier: Eier
-    ){
-        storage.fjerneHold(
+    ): Boolean {
+        return storage.fjerneHold(
             generateStorageKey(
                 dokumentId = dokumentId,
                 eier = eier

--- a/src/main/kotlin/no/nav/helse/dokument/DokumentService.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/DokumentService.kt
@@ -157,6 +157,18 @@ data class DokumentService(
         return dokumentId
     }
 
+    fun fjerneHoldPåPersistertDokument(
+        dokumentId: DokumentId,
+        eier: Eier
+    ){
+        storage.fjerneHold(
+            generateStorageKey(
+                dokumentId = dokumentId,
+                eier = eier
+            )
+        )
+    }
+
     fun dokumentHarHold(dokumentId: DokumentId, eier: Eier): Boolean = storage.harHold(generateStorageKey(dokumentId, eier))
 
     private fun generateStorageKey(

--- a/src/main/kotlin/no/nav/helse/dokument/api/dokumentV1Apis.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/api/dokumentV1Apis.kt
@@ -137,7 +137,7 @@ internal fun Route.dokumentV1Apis(
         }
     }
 
-    delete("$BASE_PATH/persistert/{dokumentId}") {
+    put("$BASE_PATH/persistert/{dokumentId}") {
         val dokumentId = call.dokumentId()
         val dokumentEier = call.dokumentEier()
         logger.info("Sletter hold på persistert dokument med id: {}", dokumentId)

--- a/src/main/kotlin/no/nav/helse/dokument/storage/GcpStorageBucket.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/storage/GcpStorageBucket.kt
@@ -60,8 +60,10 @@ class GcpStorageBucket(
         if (hold) toggleHold(key, hold)
     }
 
-    override fun fjerneHold(storageKey: StorageKey) {
+    override fun fjerneHold(storageKey: StorageKey): Boolean {
+        hent(storageKey) ?: return false
         if (harHold(storageKey)) toggleHold(storageKey, false)
+        return true
     }
 
     private fun toggleHold(key: StorageKey, hold: Boolean) {

--- a/src/main/kotlin/no/nav/helse/dokument/storage/GcpStorageBucket.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/storage/GcpStorageBucket.kt
@@ -60,6 +60,10 @@ class GcpStorageBucket(
         if (hold) toggleHold(key, hold)
     }
 
+    override fun fjerneHold(storageKey: StorageKey) {
+        if (harHold(storageKey)) toggleHold(storageKey, false)
+    }
+
     private fun toggleHold(key: StorageKey, hold: Boolean) {
         val blobInfo = hentBlobInfoBuilder(key).setTemporaryHold(hold).build()
         gcpStorage.update(blobInfo)

--- a/src/main/kotlin/no/nav/helse/dokument/storage/InMemoryStorage.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/storage/InMemoryStorage.kt
@@ -8,6 +8,11 @@ class InMemoryStorage : Storage {
     private val storage = mutableMapOf<StorageKey, StorageValue>()
     private val metadata = mutableMapOf<StorageKey, Map<String, Any>>()
 
+    override fun fjerneHold(storageKey: StorageKey) {
+        this.storage[storageKey] ?: throw IllegalStateException("Fant ikke dokument å persistere.")
+        metadata[storageKey] = mutableMapOf(BlobField.TEMPORARY_HOLD.name to false)
+    }
+
     override fun slett(storageKey: StorageKey): Boolean {
         val value = storage.remove(storageKey)
         return value != null

--- a/src/main/kotlin/no/nav/helse/dokument/storage/InMemoryStorage.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/storage/InMemoryStorage.kt
@@ -8,9 +8,10 @@ class InMemoryStorage : Storage {
     private val storage = mutableMapOf<StorageKey, StorageValue>()
     private val metadata = mutableMapOf<StorageKey, Map<String, Any>>()
 
-    override fun fjerneHold(storageKey: StorageKey) {
+    override fun fjerneHold(storageKey: StorageKey): Boolean {
         this.storage[storageKey] ?: throw IllegalStateException("Dokument med gitt storagekey ikke funnet.")
         metadata[storageKey] = mutableMapOf(BlobField.TEMPORARY_HOLD.name to false)
+        return true
     }
 
     override fun slett(storageKey: StorageKey): Boolean {

--- a/src/main/kotlin/no/nav/helse/dokument/storage/InMemoryStorage.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/storage/InMemoryStorage.kt
@@ -9,7 +9,7 @@ class InMemoryStorage : Storage {
     private val metadata = mutableMapOf<StorageKey, Map<String, Any>>()
 
     override fun fjerneHold(storageKey: StorageKey) {
-        this.storage[storageKey] ?: throw IllegalStateException("Fant ikke dokument å persistere.")
+        this.storage[storageKey] ?: throw IllegalStateException("Dokument med gitt storagekey ikke funnet.")
         metadata[storageKey] = mutableMapOf(BlobField.TEMPORARY_HOLD.name to false)
     }
 

--- a/src/main/kotlin/no/nav/helse/dokument/storage/Storage.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/storage/Storage.kt
@@ -7,7 +7,7 @@ interface Storage {
     fun persister(key: StorageKey): Boolean
     fun harHold(key: StorageKey): Boolean
     fun ready()
-    fun fjerneHold(storageKey: StorageKey)
+    fun fjerneHold(storageKey: StorageKey): Boolean
 }
 
 data class StorageKey(val value: String)

--- a/src/main/kotlin/no/nav/helse/dokument/storage/Storage.kt
+++ b/src/main/kotlin/no/nav/helse/dokument/storage/Storage.kt
@@ -7,6 +7,7 @@ interface Storage {
     fun persister(key: StorageKey): Boolean
     fun harHold(key: StorageKey): Boolean
     fun ready()
+    fun fjerneHold(storageKey: StorageKey)
 }
 
 data class StorageKey(val value: String)


### PR DESCRIPTION
Testet i dev. Se [her](https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2021-08-25T08:34:00.000Z',to:'2021-08-25T08:35:31.132Z'))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!t,params:(query:p),type:phrase),query:(match_phrase:(envclass:p)))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:'application:k9-mellomlagring'),sort:!()))

Testet at 404 fungerer [her](https://logs.adeo.no/app/discover#/?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2021-08-25T10:38:00.000Z',to:'2021-08-25T10:39:00.000Z'))&_a=(columns:!(message,envclass,level,application,host),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'96e648c0-980a-11e9-830a-e17bbd64b4db',key:envclass,negate:!t,params:(query:p),type:phrase),query:(match_phrase:(envclass:p)))),index:'96e648c0-980a-11e9-830a-e17bbd64b4db',interval:auto,query:(language:lucene,query:'application:k9-mellomlagring'),sort:!()))

Returnerer OK om det fikk fint, 404 hvis dokumentet ikke finnes
