### PR TITLE
Øker leveltid på objekter i gcp storage til 3 dager.

### DIFF
--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -12,7 +12,7 @@
   "fss-cluster": "dev-fss",
   "bucket": {
     "name": "k9-mellomlagring",
-    "objectAge": "1"
+    "objectAge": "3"
   },
   "env": {
     "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1",

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -12,7 +12,7 @@
   "fss-cluster": "prod-fss",
   "bucket": {
     "name": "k9-mellomlagring-prod",
-    "objectAge": "1"
+    "objectAge": "3"
   },
   "env": {
     "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten",


### PR DESCRIPTION
Oppdatering via nais spec har ingen påvirkering pr. dd.

Oppdaterer derfor via:
`kubectl edit storagebuckets k9-mellomlagring -n dusseldorf`
`spec.lifecycleRule.action[0].condition.age` fra 1 til 3.