### PR TITLE
Bruke token-validation-ktor fra nav i stedet for dusseldorf-auth

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.2.0
+        uses: actions/setup-java@v3.3.0
         with:
           java-version: 17
           distribution: 'zulu'
@@ -42,7 +42,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3.0.2
       - name: Set up JDK 17
-        uses: actions/setup-java@v3.2.0
+        uses: actions/setup-java@v3.3.0
         with:
           java-version: 17
           distribution: 'zulu'

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,14 +1,14 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val dusseldorfKtorVersion = "3.1.6.7-05da1a0"
+val dusseldorfKtorVersion = "3.1.6.8-403f37e"
 val ktorVersion = ext.get("ktorVersion").toString()
 val slf4jVersion = ext.get("slf4jVersion").toString()
 val amazonawsVersion = "1.11.790"
-val tikaVersion = "2.3.0"
+val tikaVersion = "2.4.0"
 val gcpStorageVersion = "2.6.1"
 val fuelVersion = "2.3.1"
-val mockKVersion = "1.12.3"
+val mockKVersion = "1.12.4"
 val jsonassertVersion = "1.5.0"
 val systemRulesVersion = "1.19.0"
 
@@ -20,7 +20,7 @@ plugins {
 }
 
 buildscript {
-    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/05da1a09b4cad3aef489f934078ac8afafe155ae/gradle/dusseldorf-ktor.gradle.kts")
+    apply("https://raw.githubusercontent.com/navikt/dusseldorf-ktor/403f37edd378c9dfc8ef7da83af04eebb0458bdc/gradle/dusseldorf-ktor.gradle.kts")
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,6 +11,8 @@ val fuelVersion = "2.3.1"
 val mockKVersion = "1.12.4"
 val jsonassertVersion = "1.5.0"
 val systemRulesVersion = "1.19.0"
+val tokenSupportVersion = "2.0.19"
+val mockOauth2ServerVersion = "0.4.6"
 
 val mainClass = "no.nav.helse.K9MellomlagringKt"
 
@@ -35,6 +37,9 @@ dependencies {
         exclude(group = "org.jetbrains.kotlinx", module = "kotlinx-coroutines-core")
     }
 
+    // Token validation
+    implementation ("no.nav.security:token-validation-ktor:$tokenSupportVersion")
+
     // Client
     implementation ( "no.nav.helse:dusseldorf-ktor-client:$dusseldorfKtorVersion")
 
@@ -46,6 +51,7 @@ dependencies {
     implementation("org.apache.tika:tika-core:$tikaVersion")
 
     // Test
+    testImplementation ("no.nav.security:mock-oauth2-server:$mockOauth2ServerVersion")
     testImplementation ( "no.nav.helse:dusseldorf-test-support:$dusseldorfKtorVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion") {
         exclude(group = "org.eclipse.jetty")

--- a/nais/dev-gcp.json
+++ b/nais/dev-gcp.json
@@ -15,7 +15,6 @@
     "objectAge": "3"
   },
   "env": {
-    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/NAVtestB2C.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten_ver1",
     "VIRUS_SCAN_URL": "http://clamav.clamav/scan",
     "BASE_URL": "https://k9-mellomlagring.dev.intern.nav.no",
     "BUCKET_NAME": "k9-mellomlagring"

--- a/nais/prod-gcp.json
+++ b/nais/prod-gcp.json
@@ -15,7 +15,6 @@
     "objectAge": "3"
   },
   "env": {
-    "LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/navnob2c.onmicrosoft.com/v2.0/.well-known/openid-configuration?p=B2C_1A_idporten",
     "VIRUS_SCAN_URL": "http://clamav.clamav/scan",
     "BASE_URL": "https://k9-mellomlagring.intern.nav.no",
     "BUCKET_NAME": "k9-mellomlagring-prod"

--- a/src/main/kotlin/no/nav/helse/Configuration.kt
+++ b/src/main/kotlin/no/nav/helse/Configuration.kt
@@ -16,17 +16,7 @@ internal data class Configuration(private val config: ApplicationConfig) {
 
     private companion object {
         private const val CRYPTO_PASSPHRASE_PREFIX = "CRYPTO_PASSPHRASE_"
-
-        private const val LOGIN_SERVICE_V1_ALIAS = "login-service-v1"
-        private const val LOGIN_SERVICE_V2_ALIAS = "login-service-v2"
     }
-
-    private val issuers = config.issuers().withAdditionalClaimRules(
-        mapOf(
-            LOGIN_SERVICE_V1_ALIAS to setOf(EnforceEqualsOrContains("acr", "Level4")),
-            LOGIN_SERVICE_V2_ALIAS to setOf(EnforceEqualsOrContains("acr", "Level4"))
-        )
-    )
 
     // Crypto
     private fun getCryptoPasshrase(key: String): String {
@@ -58,14 +48,7 @@ internal data class Configuration(private val config: ApplicationConfig) {
 
     // Auth
 
-    internal fun issuers(): Map<Issuer, Set<ClaimRule>> {
-        if (issuers.isEmpty()) throw IllegalStateException("Må konfigureres minst en issuer.")
-        return issuers
-    }
-
     val gcpBucket = config.getOptionalString(key = "nav.storage.gcp_bucket.bucket", secret = false)
-    val gcsClientServiceEndpoint =
-        config.getOptionalString(key = "nav.storage.gcp_bucket.service_endpoint", secret = false)
     val localOrTest = when (config.getOptionalString("nav.local_or_test", secret = false)) {
         "false" -> false
         "true" -> true

--- a/src/main/kotlin/no/nav/helse/K9Mellomlagring.kt
+++ b/src/main/kotlin/no/nav/helse/K9Mellomlagring.kt
@@ -67,7 +67,7 @@ fun Application.k9Mellomlagring() {
                     config = config,
                     requiredClaims = RequiredClaims(
                         issuer = issuer,
-                        claimMap = arrayOf("role=access_as_application")
+                        claimMap = arrayOf("roles=access_as_application")
                     )
                 )
             }

--- a/src/main/kotlin/no/nav/helse/K9Mellomlagring.kt
+++ b/src/main/kotlin/no/nav/helse/K9Mellomlagring.kt
@@ -41,7 +41,6 @@ fun Application.k9Mellomlagring() {
     DefaultExports.initialize()
     val logger = LoggerFactory.getLogger("no.nav.k9.k9Mellomlagring")
 
-
     val config = environment.config
     val allIssuers = config.asIssuerProps().keys
     val configuration = Configuration(config)

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -8,6 +8,27 @@ ktor {
         modules = [no.nav.helse.K9MellomlagringKt.k9Mellomlagring]
     }
 }
+
+no.nav.security.jwt {
+  issuers = [
+      {
+         issuer_name = tokendings
+         discoveryurl = ${?TOKEN_X_WELL_KNOWN_URL}
+         accepted_audience = ${?TOKEN_X_CLIENT_ID}
+      },
+      {
+        issuer_name = login-service-v2
+        discoveryurl = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
+        accepted_audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
+      },
+      {
+        issuer_name = azure
+        discoveryurl = ${?AZURE_APP_WELL_KNOWN_URL}
+        accepted_audience = ${?AZURE_APP_CLIENT_ID}
+      }
+  ]
+}
+
 nav {
     local_or_test = ""
     local_or_test = ${?LOCAL_OR_TEST}
@@ -32,35 +53,5 @@ nav {
             decryption_identifiers = "",
             decryption_identifiers = ${?CRYPTO_DECRYPTION_KEY_IDS}
         }
-    }
-    auth {
-        issuers = [{
-            alias = "login-service-v1"
-            discovery_endpoint = ""
-            discovery_endpoint = ${?LOGIN_SERVICE_V1_DISCOVERY_ENDPOINT}
-        },{
-            alias = "login-service-v2"
-            discovery_endpoint = ""
-            discovery_endpoint = ${?LOGINSERVICE_IDPORTEN_DISCOVERY_URL}
-            audience = ""
-            audience = ${?LOGINSERVICE_IDPORTEN_AUDIENCE}
-        }, {
-            alias = "azure-v2"
-            type = "azure"
-            audience = ""
-            audience = ${?AZURE_APP_CLIENT_ID}
-            discovery_endpoint = ""
-            discovery_endpoint = ${?AZURE_APP_WELL_KNOWN_URL}
-            azure {
-                require_certificate_client_authentication = "false"
-                required_roles = "access_as_application"
-            }
-        },{
-          alias = "tokenx"
-          discovery_endpoint = ""
-          discovery_endpoint = ${?TOKEN_X_WELL_KNOWN_URL}
-          audience = ""
-          audience = ${?TOKEN_X_CLIENT_ID}
-        }]
     }
 }

--- a/src/test/kotlin/no/nav/helse/K9MellomlagringApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9MellomlagringApplicationTest.kt
@@ -32,7 +32,13 @@ class K9MellomlagringApplicationTest {
             .build()
             .stubVirusScan()
 
-        private val tokenXToken = mockOAuth2Server.issueToken(fnr = "02119970078")
+        private val tokenXToken = mockOAuth2Server.issueToken(
+            issuerId = "tokendings",
+            audience = "dev-gcp:dusseldorf:k9-mellomlagring",
+            claims = mapOf("acr" to "Level4"),
+            subject = "02119970078"
+        ).serialize()
+
         private val azureToken = mockOAuth2Server.issueToken(
             issuerId = "azure",
             audience = "dev-gcp:dusseldorf:k9-mellomlagring",
@@ -158,21 +164,5 @@ class K9MellomlagringApplicationTest {
                 assertEquals(HttpStatusCode.NoContent, response.status())
             }
         }
-    }
-}
-
-fun MockOAuth2Server.issueToken(
-    fnr: String,
-    issuerId: String = "tokendings",
-    audience: String = "dev-gcp:dusseldorf:k9-mellomlagring",
-    claims: Map<String, String> = mapOf("acr" to "Level4"),
-    cookieName: String = "selvbetjening-idtoken",
-    somCookie: Boolean = false,
-): String {
-    val jwtToken =
-        issueToken(issuerId = issuerId, subject = fnr, audience = audience, claims = claims).serialize()
-    return when (somCookie) {
-        false -> jwtToken
-        true -> "$cookieName=$jwtToken"
     }
 }

--- a/src/test/kotlin/no/nav/helse/K9MellomlagringApplicationTest.kt
+++ b/src/test/kotlin/no/nav/helse/K9MellomlagringApplicationTest.kt
@@ -1,0 +1,178 @@
+package no.nav.helse
+
+import com.google.gson.JsonObject
+import com.typesafe.config.ConfigFactory
+import io.ktor.config.*
+import io.ktor.http.*
+import io.ktor.server.testing.*
+import io.prometheus.client.CollectorRegistry
+import no.nav.helse.dusseldorf.ktor.core.fromResources
+import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import org.json.JSONObject
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import kotlin.test.Test
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import java.util.*
+import kotlin.test.assertEquals
+
+class K9MellomlagringApplicationTest {
+
+    private companion object {
+
+        private val logger: Logger = LoggerFactory.getLogger(K9MellomlagringApplicationTest::class.java)
+        val mockOAuth2Server = MockOAuth2Server().apply { start() }
+        val wireMockServer = WireMockBuilder()
+            .withAzureSupport()
+            .withNaisStsSupport()
+            .withLoginServiceSupport()
+            .withTokendingsSupport()
+            .build()
+            .stubVirusScan()
+
+        private val tokenXToken = mockOAuth2Server.issueToken(fnr = "02119970078")
+        private val azureToken = mockOAuth2Server.issueToken(
+            issuerId = "azure",
+            audience = "dev-gcp:dusseldorf:k9-mellomlagring",
+            claims = mapOf("roles" to "access_as_application")
+        ).serialize()
+
+        fun getConfig(): ApplicationConfig {
+            val fileConfig = ConfigFactory.load()
+            val testConfig = ConfigFactory.parseMap(
+                TestConfiguration.asMap(
+                    wireMockServer = wireMockServer,
+                    mockOAuth2Server = mockOAuth2Server
+                )
+            )
+            val mergedConfig = testConfig.withFallback(fileConfig)
+
+            return HoconApplicationConfig(mergedConfig)
+        }
+
+        val engine = TestApplicationEngine(createTestEnvironment { config = getConfig() })
+
+        val iPhoneFil = Base64.getEncoder().encodeToString("iPhone_6.jpg".fromResources().readBytes())
+        val vedlegg = """
+            {
+                "content" : "$iPhoneFil",
+                "content_type": "image/jpeg",
+                "title" : "iPhone_6.jpeg",
+                "eier" : {
+                    "eiers_fødselsnummer" : "02119970078"
+                }
+            }
+        """.trimIndent()
+
+        @BeforeAll
+        @JvmStatic
+        fun buildUp() {
+            CollectorRegistry.defaultRegistry.clear()
+            engine.start(wait = true)
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun tearDown() {
+            logger.info("Tearing down")
+            wireMockServer.stop()
+            mockOAuth2Server.shutdown()
+            logger.info("Tear down complete")
+        }
+    }
+
+    @Test
+    fun `test isready, isalive, health og metrics`() {
+        with(engine) {
+            handleRequest(HttpMethod.Get, "/isready") {}.apply {
+                assertEquals(HttpStatusCode.OK, response.status())
+                handleRequest(HttpMethod.Get, "/isalive") {}.apply {
+                    assertEquals(HttpStatusCode.OK, response.status())
+                    handleRequest(HttpMethod.Get, "/metrics") {}.apply {
+                        assertEquals(HttpStatusCode.OK, response.status())
+                        handleRequest(HttpMethod.Get, "/health") {}.apply {
+                            assertEquals(HttpStatusCode.OK, response.status())
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `Lagre dokument med brukertoken`(){
+        with(engine){
+            handleRequest(HttpMethod.Post, "/v1/dokument" ){
+                addHeader(HttpHeaders.XCorrelationId, UUID.randomUUID().toString())
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader(HttpHeaders.ContentType, "application/json")
+                addHeader(HttpHeaders.Authorization, "Bearer $tokenXToken")
+                setBody(vedlegg)
+            }.apply {
+                assertEquals(HttpStatusCode.Created, response.status())
+            }
+        }
+    }
+
+    @Test
+    fun `Persistere dokument med brukertoken skal ikke gå`(){
+        with(engine){
+            handleRequest(HttpMethod.Put, "/v1/dokument/123/persister" ){
+                addHeader(HttpHeaders.XCorrelationId, UUID.randomUUID().toString())
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader(HttpHeaders.Authorization, "Bearer $tokenXToken")
+            }.apply {
+                assertEquals(HttpStatusCode.Forbidden, response.status())
+            }
+        }
+    }
+
+    @Test
+    fun `Persistere dokument med systemtoken skal gå`(){
+        with(engine){
+            var dokumentId: String
+            handleRequest(HttpMethod.Post, "/v1/dokument" ){
+                addHeader(HttpHeaders.XCorrelationId, UUID.randomUUID().toString())
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader(HttpHeaders.ContentType, "application/json")
+                addHeader(HttpHeaders.Authorization, "Bearer $tokenXToken")
+                setBody(vedlegg)
+            }.apply {
+                assertEquals(HttpStatusCode.Created, response.status())
+                dokumentId = JSONObject(response.content.toString()).getString("id")
+            }
+
+            handleRequest(HttpMethod.Put, "/v1/dokument/$dokumentId/persister" ){
+                addHeader(HttpHeaders.XCorrelationId, UUID.randomUUID().toString())
+                addHeader(HttpHeaders.Accept, "application/json")
+                addHeader(HttpHeaders.Authorization, "Bearer $azureToken")
+                addHeader(HttpHeaders.ContentType, "application/json")
+                setBody("""
+                    {
+                        "eiers_fødselsnummer" : "02119970078" 
+                    }
+                """.trimIndent())
+            }.apply {
+                assertEquals(HttpStatusCode.NoContent, response.status())
+            }
+        }
+    }
+}
+
+fun MockOAuth2Server.issueToken(
+    fnr: String,
+    issuerId: String = "tokendings",
+    audience: String = "dev-gcp:dusseldorf:k9-mellomlagring",
+    claims: Map<String, String> = mapOf("acr" to "Level4"),
+    cookieName: String = "selvbetjening-idtoken",
+    somCookie: Boolean = false,
+): String {
+    val jwtToken =
+        issueToken(issuerId = issuerId, subject = fnr, audience = audience, claims = claims).serialize()
+    return when (somCookie) {
+        false -> jwtToken
+        true -> "$cookieName=$jwtToken"
+    }
+}

--- a/src/test/kotlin/no/nav/helse/K9MellomlagringWithMocks.kt
+++ b/src/test/kotlin/no/nav/helse/K9MellomlagringWithMocks.kt
@@ -3,6 +3,7 @@ package no.nav.helse
 import io.ktor.server.testing.withApplication
 import no.nav.helse.dusseldorf.testsupport.asArguments
 import no.nav.helse.dusseldorf.testsupport.wiremock.WireMockBuilder
+import no.nav.security.mock.oauth2.MockOAuth2Server
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 
@@ -13,7 +14,7 @@ class K9MellomlagringWithMocks {
 
         @JvmStatic
         fun main(args: Array<String>) {
-
+            val mockOAuth2Server = MockOAuth2Server()
             val wireMockServer = WireMockBuilder()
                 .withPort(8131)
                 .withLoginServiceSupport()
@@ -24,7 +25,8 @@ class K9MellomlagringWithMocks {
 
             val testArgs = TestConfiguration.asMap(
                 wireMockServer = wireMockServer,
-                port = 8132
+                port = 8132,
+                mockOAuth2Server = mockOAuth2Server
             ).asArguments()
 
             Runtime.getRuntime().addShutdownHook(object : Thread() {

--- a/src/test/kotlin/no/nav/helse/TestConfiguration.kt
+++ b/src/test/kotlin/no/nav/helse/TestConfiguration.kt
@@ -6,6 +6,7 @@ import no.nav.helse.dusseldorf.testsupport.jws.Tokendings
 import no.nav.helse.dusseldorf.testsupport.wiremock.getAzureV2WellKnownUrl
 import no.nav.helse.dusseldorf.testsupport.wiremock.getLoginServiceV1WellKnownUrl
 import no.nav.helse.dusseldorf.testsupport.wiremock.getTokendingsWellKnownUrl
+import no.nav.security.mock.oauth2.MockOAuth2Server
 
 internal object TestConfiguration {
 
@@ -16,7 +17,8 @@ internal object TestConfiguration {
         passphrase1: String = "password",
         passphrase2: String = "oldpassword",
         passphrase3: String = "reallyoldpassword",
-        k9MellomlagringAzureClientId: String = "k9-mellomlagring"
+        k9MellomlagringAzureClientId: String = "k9-mellomlagring",
+        mockOAuth2Server: MockOAuth2Server
     ): Map<String, String> {
         val map = mutableMapOf(
             Pair("ktor.deployment.port", "$port"),
@@ -31,23 +33,18 @@ internal object TestConfiguration {
 
         // Issuers
         if (wireMockServer != null) {
-            map["nav.auth.issuers.0.alias"] = "login-service-v1"
-            map["nav.auth.issuers.0.discovery_endpoint"] = wireMockServer.getLoginServiceV1WellKnownUrl()
+            map["no.nav.security.jwt.issuers.0.issuer_name"] = "tokendings"
+            map["no.nav.security.jwt.issuers.0.discoveryurl"] = "${mockOAuth2Server.wellKnownUrl("tokendings")}"
+            map["no.nav.security.jwt.issuers.0.accepted_audience"] = "dev-gcp:dusseldorf:k9-mellomlagring"
 
-            map["nav.auth.issuers.1.alias"] = "login-service-v2"
-            map["nav.auth.issuers.1.discovery_endpoint"] = wireMockServer.getLoginServiceV1WellKnownUrl()
-            map["nav.auth.issuers.1.audience"] = LoginService.V1_0.getAudience()
+            map["no.nav.security.jwt.issuers.1.issuer_name"] = "login-service"
+            map["no.nav.security.jwt.issuers.1.discoveryurl"] = "${mockOAuth2Server.wellKnownUrl("login-service")}"
+            map["no.nav.security.jwt.issuers.1.accepted_audience"] = "dev-gcp:dusseldorf:k9-mellomlagring"
+            map["no.nav.security.jwt.issuers.1.cookie_name"] = "selvbetjening-idtoken"
 
-            map["nav.auth.issuers.2.type"] = "azure"
-            map["nav.auth.issuers.2.alias"] = "azure-v2"
-            map["nav.auth.issuers.2.discovery_endpoint"] = wireMockServer.getAzureV2WellKnownUrl()
-            map["nav.auth.issuers.2.audience"] = k9MellomlagringAzureClientId
-            map["nav.auth.issuers.2.azure.require_certificate_client_authentication"] = "false"
-            map["nav.auth.issuers.2.azure.required_roles"] = "access_as_application"
-
-            map["nav.auth.issuers.3.alias"] = "tokenx"
-            map["nav.auth.issuers.3.discovery_endpoint"] = wireMockServer.getTokendingsWellKnownUrl()
-            map["nav.auth.issuers.3.audience"] = Tokendings.getAudience()
+            map["no.nav.security.jwt.issuers.2.issuer_name"] = "azure"
+            map["no.nav.security.jwt.issuers.2.discoveryurl"] = "${mockOAuth2Server.wellKnownUrl("azure")}"
+            map["no.nav.security.jwt.issuers.2.accepted_audience"] = "dev-gcp:dusseldorf:k9-mellomlagring"
         }
 
         map["nav.local_or_test"] = "true"

--- a/src/test/kotlin/no/nav/helse/WireMockBuilderExt.kt
+++ b/src/test/kotlin/no/nav/helse/WireMockBuilderExt.kt
@@ -21,6 +21,15 @@ internal fun WireMockServer.stubVirusScan() : WireMockServer {
                     .withHeader("Content-Type", "application/json")
                     .withStatus(200)
                     .withTransformers("virus-scan")
+                    .withBody(
+                        """
+                        [
+                            {
+                                "Result" : "OK"
+                            }
+                        ]
+                    """.trimIndent()
+                    )
             )
     )
     return this


### PR DESCRIPTION
Legger til test som verifiserer at kun systemtoken kan persistere dokumenter. 

[Oppdatere pakker.](https://github.com/navikt/k9-mellomlagring/commit/174dc1403630e92135bdefc9d531f7beaaa6fefa) 

* Closes https://github.com/navikt/k9-mellomlagring/pull/163
* Closes https://github.com/navikt/k9-mellomlagring/pull/162
* Closes https://github.com/navikt/k9-mellomlagring/pull/161
* Closes https://github.com/navikt/k9-mellomlagring/pull/148